### PR TITLE
fix #7 loginが詳細画面へ戻れる度に設定される不具合の対応

### DIFF
--- a/app/src/main/java/com/example/contributors/fragments/MainFragment.kt
+++ b/app/src/main/java/com/example/contributors/fragments/MainFragment.kt
@@ -53,9 +53,9 @@ class MainFragment : Fragment() {
             }
             Snackbar.make(view, it, Snackbar.LENGTH_LONG).show()
         })
-        mainViewModel.openDetail.observe(viewLifecycleOwner, Observer {
+        mainViewModel.openDetail.observe(viewLifecycleOwner, EventObserver {
             if (it == "") {
-                return@Observer
+                return@EventObserver
             }
             navigateDetail(it)
         })

--- a/app/src/main/java/com/example/contributors/util/Event.kt
+++ b/app/src/main/java/com/example/contributors/util/Event.kt
@@ -1,0 +1,28 @@
+package com.example.contributors.util
+
+import androidx.lifecycle.Observer
+
+open class Event<out T>(private val content: T) {
+
+    var hasBeenHandled = false
+        private set // Allow external read but not write
+
+    fun getContentIfNotHandled(): T? {
+        return if (hasBeenHandled) {
+            null
+        } else {
+            hasBeenHandled = true
+            content
+        }
+    }
+
+    fun peekContent(): T = content
+}
+
+class EventObserver<T>(private val onEventUnhandledContent: (T) -> Unit) : Observer<Event<T>> {
+    override fun onChanged(event: Event<T>?) {
+        event?.getContentIfNotHandled()?.let { value ->
+            onEventUnhandledContent(value)
+        }
+    }
+}

--- a/app/src/main/java/com/example/contributors/viewModel/MainViewModel.kt
+++ b/app/src/main/java/com/example/contributors/viewModel/MainViewModel.kt
@@ -26,8 +26,8 @@ class MainViewModel @Inject constructor(private val repository: ContributorRepos
     private val _snackbarText = MutableLiveData("")
     val snackbarText: LiveData<String> = _snackbarText
 
-    private val _openDetail = MutableLiveData("")
-    val openDetail: LiveData<String> = _openDetail
+    private val _openDetail = MutableLiveData<Event<String>>()
+    val openDetail: LiveData<Event<String>> = _openDetail
 
     fun load() {
         _dataLoading.value = true
@@ -44,6 +44,6 @@ class MainViewModel @Inject constructor(private val repository: ContributorRepos
     }
 
     fun openDetail(taskId: String) {
-        _openDetail.value = taskId
+        _openDetail.value = Event(taskId)
     }
 }


### PR DESCRIPTION
Event Wrapperを用いていないため、詳細から一覧のfragmentに戻ると、LiveDataオブザーバーに既存の値が再度通知される。
そのため、無限に詳細画面が再表示されていた。
https://stackoverflow.com/questions/58342060/why-is-onchanged-being-called-when-i-navigate-back-to-a-fragment