### PR TITLE
Snackbarの出力メッセージ監視をEvent Wrapperで行う

### DIFF
--- a/app/src/main/java/com/example/contributors/fragments/DetailFragment.kt
+++ b/app/src/main/java/com/example/contributors/fragments/DetailFragment.kt
@@ -12,7 +12,7 @@ import androidx.lifecycle.Observer
 import androidx.navigation.fragment.navArgs
 import com.example.contributors.R
 import com.example.contributors.databinding.DetailFragmentBinding
-import com.example.contributors.databinding.MainFragmentBinding
+import com.example.contributors.util.EventObserver
 import com.example.contributors.viewModel.DetailViewModel
 import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
@@ -51,9 +51,9 @@ class DetailFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.lifecycleOwner = this
-        detailViewModel.snackbarText.observe(viewLifecycleOwner, Observer {
+        detailViewModel.snackbarText.observe(viewLifecycleOwner, EventObserver {
             if (it == "") {
-                return@Observer
+                return@EventObserver
             }
             Snackbar.make(view, it, Snackbar.LENGTH_LONG).show()
         })

--- a/app/src/main/java/com/example/contributors/fragments/MainFragment.kt
+++ b/app/src/main/java/com/example/contributors/fragments/MainFragment.kt
@@ -10,16 +10,13 @@ import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import com.example.contributors.adapter.ContributorsAdapter
 import com.example.contributors.databinding.MainFragmentBinding
+import com.example.contributors.util.EventObserver
 import com.example.contributors.viewModel.MainViewModel
 import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainFragment : Fragment() {
-
-    companion object {
-        fun newInstance() = MainFragment()
-    }
 
     private val mainViewModel by viewModels<MainViewModel>()
     private lateinit var binding: MainFragmentBinding
@@ -47,9 +44,9 @@ class MainFragment : Fragment() {
         mainViewModel.items.observe(viewLifecycleOwner, Observer{
             listAdapter.submitList(it)
         })
-        mainViewModel.snackbarText.observe(viewLifecycleOwner, Observer {
+        mainViewModel.snackbarText.observe(viewLifecycleOwner, EventObserver {
             if (it == "") {
-                return@Observer
+                return@EventObserver
             }
             Snackbar.make(view, it, Snackbar.LENGTH_LONG).show()
         })

--- a/app/src/main/java/com/example/contributors/viewModel/DetailViewModel.kt
+++ b/app/src/main/java/com/example/contributors/viewModel/DetailViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.*
 import com.example.contributors.R
 import com.example.contributors.model.ContributorDetail
 import com.example.contributors.repository.ContributorRepository
+import com.example.contributors.util.Event
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -19,8 +20,8 @@ class DetailViewModel @AssistedInject constructor(private val repository: Contri
     private val _dataLoading = MutableLiveData<Boolean>(false)
     val dataLoading: LiveData<Boolean> = _dataLoading
 
-    private val _snackbarText = MutableLiveData<String>("")
-    val snackbarText: LiveData<String> = _snackbarText
+    private val _snackbarText = MutableLiveData<Event<String>>()
+    val snackbarText: LiveData<Event<String>> = _snackbarText
 
     private val _model = MutableLiveData<ContributorDetail>()
     val model: LiveData<ContributorDetail> = _model
@@ -35,7 +36,7 @@ class DetailViewModel @AssistedInject constructor(private val repository: Contri
                 _model.postValue(body)
                 return@launch
             }
-            _snackbarText.postValue(context.getString(R.string.deta_load_error_message))
+            _snackbarText.postValue(Event(context.getString(R.string.deta_load_error_message)))
         }
     }
 

--- a/app/src/main/java/com/example/contributors/viewModel/MainViewModel.kt
+++ b/app/src/main/java/com/example/contributors/viewModel/MainViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.viewModelScope
 import com.example.contributors.R
 import com.example.contributors.model.Contributor
 import com.example.contributors.repository.ContributorRepository
+import com.example.contributors.util.Event
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
@@ -23,8 +24,8 @@ class MainViewModel @Inject constructor(private val repository: ContributorRepos
     private val _dataLoading = MutableLiveData(false)
     val dataLoading: LiveData<Boolean> = _dataLoading
 
-    private val _snackbarText = MutableLiveData("")
-    val snackbarText: LiveData<String> = _snackbarText
+    private val _snackbarText = MutableLiveData<Event<String>>()
+    val snackbarText: LiveData<Event<String>> = _snackbarText
 
     private val _openDetail = MutableLiveData<Event<String>>()
     val openDetail: LiveData<Event<String>> = _openDetail
@@ -39,7 +40,7 @@ class MainViewModel @Inject constructor(private val repository: ContributorRepos
                 _items.postValue(body)
                 return@launch
             }
-            _snackbarText.postValue(context.getString(R.string.deta_load_error_message))
+            _snackbarText.postValue(Event(context.getString(R.string.deta_load_error_message)))
         }
     }
 


### PR DESCRIPTION
SnackbarのObserverにも #7 と同じ対応を行った。
対応理由としては、エラーメッセージが設定されている場合でonChangedが呼ばれた場合、再度Snackbarのメッセージが表示されることとなるため。