### PR TITLE
詳細画面表示時に必要なデータを読み込むタイミングを変更した

### DIFF
--- a/app/src/main/java/com/example/contributors/fragments/DetailFragment.kt
+++ b/app/src/main/java/com/example/contributors/fragments/DetailFragment.kt
@@ -25,6 +25,7 @@ class DetailFragment : Fragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         login = args.login
+        detailViewModel.load()
     }
 
     @Inject
@@ -52,10 +53,5 @@ class DetailFragment : Fragment() {
             }
             Snackbar.make(view, it, Snackbar.LENGTH_LONG).show()
         })
-    }
-
-    override fun onResume() {
-        super.onResume()
-        detailViewModel.load()
     }
 }


### PR DESCRIPTION
onCreateで詳細画面表示時に必要なデータを読み込む用に変更。
画面再立ち上げ等で再度取得するほどでもないと判断。